### PR TITLE
No SGR params; eliminate dependency on unmaintained ansi_term crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/dandavison/vte-ansi-tools"
 license = "MIT"
 
 [dependencies]
-ansi_term = "0.12.1"
 itertools = "0.10.3"
 lazy_static = "1.4"
 unicode-segmentation = "1.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,11 @@ license = "MIT"
 
 [dependencies]
 ansi_term = "0.12.1"
-console = "0.15.0" # TODO: tests only
 itertools = "0.10.3"
 lazy_static = "1.4"
 unicode-segmentation = "1.9.0"
 unicode-width = "0.1.9"
 vte = "0.10.1"
+
+[dev-dependencies]
+console = "0.15.0"


### PR DESCRIPTION
cc @zhiburt 

Future work can bring back the SGR params exposed in a different way (delta will need this in order to be able to use this library).